### PR TITLE
returns the value of semaphore take() call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ SemaphoreMap.prototype.take = function (key, fn) {
     this._semaphores.set(key, semaphore);
   }
 
-  semaphore.take(function () {
+  return semaphore.take(function () {
     // Strip the semaphore argument from the take callback because
     // if the semaphore is leaked then it might be used to leave
     // instead of the keyed leave below

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 'use strict';
 const SemaphoreMap = require('../src/index');
 const sinon = require('sinon');
+const assert = require('assert');
 
 describe('#take', function () {
   it('when called with the same key twice, it uses the same semaphore', function () {
@@ -36,6 +37,22 @@ describe('#take', function () {
     const secondFunc = sinon.stub();
     map.take('key2', secondFunc);
     sinon.assert.calledOnce(secondFunc);
+  });
+
+  it('returns queue size when exceeds capacity', function () {
+    const map = new SemaphoreMap();
+    function func () {}
+    let ret = map.take('one', func);
+    assert.strictEqual(ret, undefined);
+
+    ret = map.take('one', func);
+    assert.strictEqual(ret, 1);
+
+    ret = map.take('one', func);
+    assert.strictEqual(ret, 2);
+
+    ret = map.take('two', func);
+    assert.strictEqual(ret, undefined);
   });
 });
 


### PR DESCRIPTION
Hi Matt! SInce the base emaphore module returns the size of the queue thought the map version should as well.